### PR TITLE
ignore view controllers for swagger

### DIFF
--- a/dpp.opentakrouter/Controllers/HomeController.cs
+++ b/dpp.opentakrouter/Controllers/HomeController.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace dpp.opentakrouter.Controllers
 {
+    [ApiExplorerSettings(IgnoreApi=true)]
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;


### PR DESCRIPTION
we don't want views for end users in the swagger docs. let's hide them.