### PR TITLE
websockets use parsed event

### DIFF
--- a/dpp.opentakrouter/TakWsServer.cs
+++ b/dpp.opentakrouter/TakWsServer.cs
@@ -23,7 +23,8 @@ namespace dpp.opentakrouter
 
         protected void OnRoutedEvent(object sender, RoutedEventArgs e)
         {
-            var xml = Encoding.UTF8.GetString(e.Data);
+            // TODO: can websockets be raw data (i.e. protobuf), or should they just be the xml event?
+            var xml = e.Event.ToXmlString();
             _ = this.MulticastText(xml);
         }
 

--- a/dpp.opentakrouter/TakWssServer.cs
+++ b/dpp.opentakrouter/TakWssServer.cs
@@ -23,7 +23,8 @@ namespace dpp.opentakrouter
 
         protected void OnRoutedEvent(object sender, RoutedEventArgs e)
         {
-            var xml = Encoding.UTF8.GetString(e.Data);
+            // TODO: can websockets be raw data (i.e. protobuf), or should they just be the xml event?
+            var xml = e.Event.ToXmlString();
             _ = this.MulticastText(xml);
         }
 


### PR DESCRIPTION
Until I figure out what's going on with websockets, let's just use the parsed xml and avoid any version preamble issues.

Fixes #20 