### PR TITLE
Add handlers for Windows and Systemd

### DIFF
--- a/dpp.opentakrouter/dpp.opentakrouter.csproj
+++ b/dpp.opentakrouter/dpp.opentakrouter.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <PackageReference Include="dpp.cot" Version="1.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="5.0.1" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />


### PR DESCRIPTION
Windows requires some handlers to implement a process as a service. System does something similar. This adds both. Additionally, since running as a Windows service output is no longer allocated to a console, we send logs to the data directory.

Closes #28.