### PR TITLE
Better default logging

### DIFF
--- a/dpp.opentakrouter/Program.cs
+++ b/dpp.opentakrouter/Program.cs
@@ -29,6 +29,7 @@ namespace dpp.opentakrouter
                 );
 
             var logFile = Path.Combine(dataDir, "opentakrouter.log");
+            var flushInterval = new TimeSpan(0, 0, 1);
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
@@ -36,7 +37,10 @@ namespace dpp.opentakrouter
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
-                .WriteTo.File(logFile, flushToDiskInterval: new TimeSpan(0, 0, 1))
+                .WriteTo.File(
+                    logFile, 
+                    flushToDiskInterval: flushInterval,
+                    rollingInterval: RollingInterval.Day)
                 .CreateBootstrapLogger();
 
             return Host.CreateDefaultBuilder(args)
@@ -53,7 +57,10 @@ namespace dpp.opentakrouter
                     .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                     .Enrich.FromLogContext()
                     .WriteTo.Console()
-                    .WriteTo.File(logFile, flushToDiskInterval: new TimeSpan(0, 0, 1)))
+                    .WriteTo.File(
+                        logFile,
+                        flushToDiskInterval: flushInterval,
+                        rollingInterval: RollingInterval.Day))
                 .ConfigureServices((context, services) =>
                 {
                     services.AddScoped<IDatabaseContext, DatabaseContext>();

--- a/dpp.opentakrouter/Program.cs
+++ b/dpp.opentakrouter/Program.cs
@@ -31,6 +31,7 @@ namespace dpp.opentakrouter
             var logFile = Path.Combine(dataDir, "opentakrouter.log");
 
             Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
@@ -44,6 +45,15 @@ namespace dpp.opentakrouter
                     builder.Sources.Clear();
                     builder.AddConfiguration(configuration);
                 })
+                .UseSerilog((context, services, configuration) => configuration
+                    .ReadFrom.Configuration(context.Configuration)
+                    .ReadFrom.Services(services)
+                    .MinimumLevel.Debug()
+                    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                    .Enrich.FromLogContext()
+                    .WriteTo.Console()
+                    .WriteTo.File(logFile, flushToDiskInterval: new TimeSpan(0, 0, 1)))
                 .ConfigureServices((context, services) =>
                 {
                     services.AddScoped<IDatabaseContext, DatabaseContext>();
@@ -83,12 +93,6 @@ namespace dpp.opentakrouter
                     });
                     builder.UseStartup<WebService>();
                 })
-                .UseSerilog((context, services, configuration) => configuration
-                    .ReadFrom.Configuration(context.Configuration)
-                    .ReadFrom.Services(services)
-                    .Enrich.FromLogContext()
-                    .WriteTo.Console()
-                    .WriteTo.File(logFile, flushToDiskInterval: new TimeSpan(0, 0, 1)))
                 .UseWindowsService()
                 .UseSystemd();
 

--- a/dpp.opentakrouter/TakService.cs
+++ b/dpp.opentakrouter/TakService.cs
@@ -42,11 +42,11 @@ namespace dpp.opentakrouter
                         tcpServerConfig.Port,
                         router: router);
                     _tcpServer.Start();
-                    Log.Information("server=tcp state=started");
+                    Log.Information("server=tak-tcp state=started");
                 }
                 else
                 {
-                    Log.Information("server=tcp state=skipped");
+                    Log.Information("server=tak-tcp state=skipped");
                 }
 
                 var tlsServerConfig = configuration.GetSection("server:tak:tls").Get<TakServerConfig>();
@@ -63,11 +63,11 @@ namespace dpp.opentakrouter
                         tlsServerConfig.Port,
                         router: router);
                     _tlsServer.Start();
-                    Log.Information("server=tls state=started");
+                    Log.Information("server=tak-ssl state=started");
                 }
                 else
                 {
-                    Log.Information("server=tls state=skipped");
+                    Log.Information("server=tak-ssl state=skipped");
                 }
 
                 var websocketConfig = configuration.GetSection("server:websockets").Get<WebConfig>();

--- a/dpp.opentakrouter/TakTcpPeer.cs
+++ b/dpp.opentakrouter/TakTcpPeer.cs
@@ -95,7 +95,7 @@ namespace dpp.opentakrouter
                         return;
                     }
 
-                    Log.Information($"peer={_name} event=cot type={msg.Event.Type}");
+                    Log.Information($"peer={_name} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
                     _router.Send(msg.Event, buffer);
                 }
                 catch (Exception e)

--- a/dpp.opentakrouter/TakTcpServer.cs
+++ b/dpp.opentakrouter/TakTcpServer.cs
@@ -27,7 +27,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id=server error={error}");
+            Log.Error($"server=tak-tcp error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakTcpSession.cs
+++ b/dpp.opentakrouter/TakTcpSession.cs
@@ -15,12 +15,12 @@ namespace dpp.opentakrouter
         }
         protected override void OnConnected()
         {
-            Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} state=connected");
+            Log.Information($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
         }
 
         protected override void OnDisconnected()
         {
-            Log.Information($"id={Id} state=disconnected");
+            Log.Information($"server=tak-tcp session={Id} state=disconnected");
         }
 
         protected override void OnReceived(byte[] buffer, long offset, long size)
@@ -28,24 +28,24 @@ namespace dpp.opentakrouter
             try
             {
                 var msg = Message.Parse(buffer, (int)offset, (int)size);
+                Log.Information($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
                 if (msg.Event.IsA(CotPredicates.t_ping))
                 {
-                    Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} event=cot-ping");
                     SendAsync(Event.Pong(msg.Event).ToXmlString());
+                    return;
                 }
 
-                Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} event=cot type={msg.Event.Type}");
                 _router.Send(msg.Event, buffer);
             }
             catch (Exception e)
             {
-                Log.Error(e, $"id={Id} endpoint={Socket.RemoteEndPoint} type=unknown error=true forwarded=false");
+                Log.Error(e, $"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id={Id} error={error}");
+            Log.Error($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakTlsServer.cs
+++ b/dpp.opentakrouter/TakTlsServer.cs
@@ -27,7 +27,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id=server error={error}");
+            Log.Error($"server=tak-ssl error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakTlsSession.cs
+++ b/dpp.opentakrouter/TakTlsSession.cs
@@ -16,37 +16,37 @@ namespace dpp.opentakrouter
         }
         protected override void OnConnected()
         {
-            Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} state=connected");
+            Log.Information($"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
         }
 
         protected override void OnDisconnected()
         {
-            Log.Information($"id={Id} state=disconnected");
+            Log.Information($"server=tak-ssl session={Id} state=disconnected");
         }
 
         protected override void OnReceived(byte[] buffer, long offset, long size)
         {
             try
             {
-                var msgstr = Encoding.UTF8.GetString(buffer);
                 var msg = Message.Parse(buffer, (int)offset, (int)size);
+                Log.Information($"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
                 if (msg.Event.IsA(CotPredicates.t_ping))
                 {
-                    Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} event=cot-ping");
                     SendAsync(Event.Pong(msg.Event).ToXmlString());
+                    return;
                 }
 
                 _router.Send(msg.Event, buffer);
             }
             catch (Exception e)
             {
-                Log.Error(e, $"id={Id} endpoint={Socket.RemoteEndPoint} type=unknown error=true forwarded=false");
+                Log.Error(e, $"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id={Id} error={error}");
+            Log.Error($"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakWsServer.cs
+++ b/dpp.opentakrouter/TakWsServer.cs
@@ -30,7 +30,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id=server error={error}");
+            Log.Error($"server=ws error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakWsSession.cs
+++ b/dpp.opentakrouter/TakWsSession.cs
@@ -15,12 +15,12 @@ namespace dpp.opentakrouter
         }
         public override void OnWsConnected(HttpRequest request)
         {
-            Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} state=connected");
+            Log.Information($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
         }
 
         public override void OnWsDisconnected()
         {
-            Log.Information($"id={Id} state=disconnected");
+            Log.Information($"server=ws session={Id} state=disconnected");
         }
 
         public override void OnWsReceived(byte[] buffer, long offset, long size)
@@ -29,18 +29,18 @@ namespace dpp.opentakrouter
             {
                 var msg = Message.Parse(buffer, (int)offset, (int)size);
 
-                Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} event=cot type={msg.Event.Type}");
+                Log.Information($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
                 _router.Send(msg.Event, buffer);
             }
             catch (Exception e)
             {
-                Log.Error(e, $"id={Id} endpoint={Socket.RemoteEndPoint} type=unknown error=true forwarded=false");
+                Log.Error(e, $"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id={Id} error={error}");
+            Log.Error($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakWssServer.cs
+++ b/dpp.opentakrouter/TakWssServer.cs
@@ -30,7 +30,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id=server error={error}");
+            Log.Error($"server=wss id=server error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/TakWssSession.cs
+++ b/dpp.opentakrouter/TakWssSession.cs
@@ -15,12 +15,12 @@ namespace dpp.opentakrouter
         }
         public override void OnWsConnected(HttpRequest request)
         {
-            Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} state=connected");
+            Log.Information($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
         }
 
         public override void OnWsDisconnected()
         {
-            Log.Information($"id={Id} state=disconnected");
+            Log.Information($"server=wss session={Id} state=disconnected");
         }
 
         public override void OnWsReceived(byte[] buffer, long offset, long size)
@@ -29,18 +29,18 @@ namespace dpp.opentakrouter
             {
                 var msg = Message.Parse(buffer, (int)offset, (int)size);
 
-                Log.Information($"id={Id} endpoint={Socket.RemoteEndPoint} event=cot type={msg.Event.Type}");
+                Log.Information($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
                 _router.Send(msg.Event, buffer);
             }
             catch (Exception e)
             {
-                Log.Error(e, $"id={Id} endpoint={Socket.RemoteEndPoint} type=unknown error=true forwarded=false");
+                Log.Error(e, $"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"id={Id} error={error}");
+            Log.Error($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
         }
     }
 }

--- a/dpp.opentakrouter/WebService.cs
+++ b/dpp.opentakrouter/WebService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using Serilog;
 
 namespace dpp.opentakrouter
 {
@@ -42,6 +43,14 @@ namespace dpp.opentakrouter
             }
 
             app.UseStaticFiles();
+            app.UseSerilogRequestLogging(options =>
+            {
+                options.MessageTemplate = "server=web endpoint={RemoteIpAddress} method={RequestMethod} req={RequestPath} status={StatusCode} ms={Elapsed}";
+                options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+                {
+                    diagnosticContext.Set("RemoteIpAddress", httpContext.Connection.RemoteIpAddress);
+                };
+            });
             app.UseRouting();
             app.UseAuthorization();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
This normalizes the taxonomy used throughout logs. All server components now share `endpoint` to describe client endpoints. Additionally, the log file now rotates by default on a daily interval up to the default of 31 days.

Closes #27.