### PR TITLE
Add API to ingest events

### DIFF
--- a/dpp.opentakrouter/Controllers/EventsController.cs
+++ b/dpp.opentakrouter/Controllers/EventsController.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Mime;
+using System.Text;
+
+namespace dpp.opentakrouter.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class EventsController : ControllerBase
+    {
+        private readonly ILogger<EventsController> _logger;
+        private readonly IRouter _router;
+
+        public EventsController(ILogger<EventsController> logger, IRouter router)
+        {
+            _logger = logger;
+            _router = router;
+        }
+
+        [Route("/api/events")]
+        [HttpPost]
+        [Consumes(MediaTypeNames.Application.Xml)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public IActionResult SubmitEvent()
+        {
+            try
+            {
+                using (var sr = new StreamReader(Request.BodyReader.AsStream()))
+                {
+                    var data = sr.ReadToEnd();
+                    var evt = cot.Event.Parse(data);
+                    _router.Send(evt, null);
+                }
+            }
+            catch
+            {
+                return BadRequest();
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/dpp.opentakrouter/Program.cs
+++ b/dpp.opentakrouter/Program.cs
@@ -67,7 +67,7 @@ namespace dpp.opentakrouter
                     services.AddScoped<IClientRepository, ClientRepository>();
                     services.AddScoped<IMessageRepository, MessageRepository>();
                     services.AddScoped<IDataPackageRepository, DataPackageRepository>();
-                    services.AddScoped<IRouter, Router>();
+                    services.AddSingleton<IRouter, Router>();
                     services.AddHostedService<TakService>();
                 })
                 .ConfigureWebHostDefaults(builder =>


### PR DESCRIPTION
Adds an API endpoint to ingest events. Events are assumed to be CoT events in xml format. This also transitions the core router instance to become a singleton rather than scoped to a single thread.