### PR TITLE
Fix missing client libraries

### DIFF
--- a/dpp.opentakrouter/libman.json
+++ b/dpp.opentakrouter/libman.json
@@ -3,6 +3,14 @@
   "defaultProvider": "cdnjs",
   "libraries": [
     {
+      "library": "jquery@3.6.0",
+      "destination": "wwwroot/lib/jquery/"
+    },
+    {
+        "library": "bootstrap@5.1.3",
+        "destination": "wwwroot/lib/bootstrap/"
+    },
+    {
       "library": "admin-lte@3.2.0",
       "destination": "wwwroot/lib/admin-lte/"
     },


### PR DESCRIPTION
When the embedded dependencies were pruned the libman entries for jquery and bootstrap were overlooked.