### PR TITLE
Improve handling buffer, router

### DIFF
--- a/dpp.opentakrouter/Controllers/EventsController.cs
+++ b/dpp.opentakrouter/Controllers/EventsController.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
-using System.Text;
 
 namespace dpp.opentakrouter.Controllers
 {

--- a/dpp.opentakrouter/DatabaseContext.cs
+++ b/dpp.opentakrouter/DatabaseContext.cs
@@ -25,6 +25,7 @@ namespace dpp.opentakrouter
                 null, null, null, null);
 
             Database = new SQLiteConnection(options);
+
         }
     }
 }

--- a/dpp.opentakrouter/IMessageRepository.cs
+++ b/dpp.opentakrouter/IMessageRepository.cs
@@ -8,7 +8,11 @@ namespace dpp.opentakrouter
         public IEnumerable<StoredMessage> Search(string keywords = "");
         public StoredMessage Get(string UID);
         public int Add(StoredMessage msg);
+
+        public int Upsert(StoredMessage msg);
         public int Update(StoredMessage msg);
         public int Delete(string UID);
+        public int EvictExpired();
+        IEnumerable<StoredMessage> GetActive();
     }
 }

--- a/dpp.opentakrouter/IRouter.cs
+++ b/dpp.opentakrouter/IRouter.cs
@@ -1,5 +1,6 @@
 ﻿using dpp.cot;
 using System;
+using System.Collections.Generic;
 
 namespace dpp.opentakrouter
 {
@@ -7,5 +8,6 @@ namespace dpp.opentakrouter
     {
         public event EventHandler<RoutedEventArgs> RaiseRoutedEvent;
         public void Send(Event e, byte[] data);
+        IEnumerable<Event> GetActiveEvents();
     }
 }

--- a/dpp.opentakrouter/Models/StoredMessage.cs
+++ b/dpp.opentakrouter/Models/StoredMessage.cs
@@ -8,9 +8,12 @@ namespace dpp.opentakrouter.Models
         [PrimaryKey, AutoIncrement]
         public int PrimaryKey { get; set; }
 
+        [Indexed]
         public string Uid { get; set; }
         public string Data { get; set; }
         public DateTime Timestamp { get; set; } = DateTime.Now;
+
+        [Indexed]
         public DateTime Expiration { get; set; } = DateTime.Now.AddMinutes(5);
 
         [Ignore]

--- a/dpp.opentakrouter/Program.cs
+++ b/dpp.opentakrouter/Program.cs
@@ -38,7 +38,7 @@ namespace dpp.opentakrouter
                 .Enrich.FromLogContext()
                 .WriteTo.Console()
                 .WriteTo.File(
-                    logFile, 
+                    logFile,
                     flushToDiskInterval: flushInterval,
                     rollingInterval: RollingInterval.Day)
                 .CreateBootstrapLogger();
@@ -106,6 +106,14 @@ namespace dpp.opentakrouter
         }
         static async System.Threading.Tasks.Task Main(string[] args)
         {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                if (Console.LargestWindowWidth != 0)
+                {
+
+                }
+            }
+
 
             var hostBuilder = Initialize(args);
 

--- a/dpp.opentakrouter/Router.cs
+++ b/dpp.opentakrouter/Router.cs
@@ -1,21 +1,41 @@
 ﻿using dpp.cot;
 using dpp.opentakrouter.Models;
+using Microsoft.Extensions.Configuration;
 using System;
+using System.Collections.Generic;
 
 namespace dpp.opentakrouter
 {
     public class Router : IRouter
     {
+        private readonly IConfiguration _configuration;
         private readonly IClientRepository _clients;
         private readonly IMessageRepository _messages;
 
-        public Router(IClientRepository clients, IMessageRepository messages)
+        private readonly bool _persistMessages;
+
+        public Router(IConfiguration configuration, IClientRepository clients, IMessageRepository messages)
         {
+            _configuration = configuration;
             _clients = clients;
             _messages = messages;
+
+            _persistMessages = _configuration.GetValue("server:persist_messages", false);
         }
 
         public event EventHandler<RoutedEventArgs> RaiseRoutedEvent;
+
+        public IEnumerable<Event> GetActiveEvents()
+        {
+            List<Event> results = new();
+
+            foreach (var evt in _messages.GetActive())
+            {
+                results.Add(Event.Parse(evt.Data));
+            }
+
+            return results;
+        }
 
         public void Send(Event e, byte[] data)
         {
@@ -35,13 +55,16 @@ namespace dpp.opentakrouter
                 return;
             }
 
-            _messages.Add(new Models.StoredMessage()
+            if (_persistMessages)
             {
-                Uid = e.Uid,
-                Data = e.ToXmlString(),
-                Timestamp = e.Time,
-                Expiration = e.Stale
-            });
+                _messages.Upsert(new Models.StoredMessage()
+                {
+                    Uid = e.Uid,
+                    Data = e.ToXmlString(),
+                    Timestamp = e.Time,
+                    Expiration = e.Stale
+                });
+            }
 
             OnRaiseRoutedEvent(new RoutedEventArgs(e, data));
         }

--- a/dpp.opentakrouter/Router.cs
+++ b/dpp.opentakrouter/Router.cs
@@ -20,7 +20,7 @@ namespace dpp.opentakrouter
             _clients = clients;
             _messages = messages;
 
-            _persistMessages = _configuration.GetValue("server:persist_messages", false);
+            _persistMessages = _configuration.GetValue("server:persist_messages", true);
         }
 
         public event EventHandler<RoutedEventArgs> RaiseRoutedEvent;

--- a/dpp.opentakrouter/TakTcpPeer.cs
+++ b/dpp.opentakrouter/TakTcpPeer.cs
@@ -98,7 +98,7 @@ namespace dpp.opentakrouter
                 {
                     var data = Encoding.UTF8.GetString(buffer);
 
-                    foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                    foreach (Match match in Regex.Matches(data, @"<event.+?\/event>"))
                     {
                         try
                         {

--- a/dpp.opentakrouter/TakTcpSession.cs
+++ b/dpp.opentakrouter/TakTcpSession.cs
@@ -3,12 +3,15 @@ using NetCoreServer;
 using Serilog;
 using System;
 using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace dpp.opentakrouter
 {
     public class TakTcpSession : TcpSession
     {
         private readonly IRouter _router;
+        private const string _component = "tak-tcp";
         public TakTcpSession(TakTcpServer server) : base(server)
         {
             _router = server.Router;
@@ -16,30 +19,51 @@ namespace dpp.opentakrouter
         protected override void OnConnected()
         {
             Log.Information($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
+            foreach (var evt in _router.GetActiveEvents())
+            {
+                SendAsync(evt.ToXmlString());
+            }
         }
 
         protected override void OnDisconnected()
         {
             Log.Information($"server=tak-tcp session={Id} state=disconnected");
         }
-
         protected override void OnReceived(byte[] buffer, long offset, long size)
         {
             try
             {
-                var msg = Message.Parse(buffer, (int)offset, (int)size);
-                Log.Information($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
-                if (msg.Event.IsA(CotPredicates.t_ping))
-                {
-                    SendAsync(Event.Pong(msg.Event).ToXmlString());
-                    return;
-                }
+                var data = Encoding.UTF8.GetString(buffer);
 
-                _router.Send(msg.Event, buffer);
+                foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                {
+                    try
+                    {
+                        var evt = Event.Parse(match.Value);
+                        Log.Information($"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={evt.Uid} type={evt.Type}");
+                        if (evt.IsA(CotPredicates.t_ping))
+                        {
+                            SendAsync(Event.Pong(evt).ToXmlString());
+                            return;
+                        }
+
+                        _router.Send(evt, buffer);
+                    }
+                    catch (OverflowException)
+                    {
+                        Log.Error($"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"Overflow error. Receiving too much data.\"");
+
+                        // TODO: no real backoff control. kill connection?
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                    }
+                }
             }
             catch (Exception e)
             {
-                Log.Error(e, $"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
             }
         }
 

--- a/dpp.opentakrouter/TakTcpSession.cs
+++ b/dpp.opentakrouter/TakTcpSession.cs
@@ -35,7 +35,7 @@ namespace dpp.opentakrouter
             {
                 var data = Encoding.UTF8.GetString(buffer);
 
-                foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                foreach (Match match in Regex.Matches(data, @"<event.+?\/event>"))
                 {
                     try
                     {
@@ -57,13 +57,13 @@ namespace dpp.opentakrouter
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                        Log.Error($"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
                     }
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                Log.Error($"server={_component} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
             }
         }
 

--- a/dpp.opentakrouter/TakTlsSession.cs
+++ b/dpp.opentakrouter/TakTlsSession.cs
@@ -36,7 +36,7 @@ namespace dpp.opentakrouter
             {
                 var data = Encoding.UTF8.GetString(buffer);
 
-                foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                foreach (Match match in Regex.Matches(data, @"<event.+?\/event>"))
                 {
                     try
                     {

--- a/dpp.opentakrouter/TakWsServer.cs
+++ b/dpp.opentakrouter/TakWsServer.cs
@@ -2,7 +2,6 @@
 using Serilog;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 
 namespace dpp.opentakrouter
 {

--- a/dpp.opentakrouter/TakWsSession.cs
+++ b/dpp.opentakrouter/TakWsSession.cs
@@ -3,6 +3,8 @@ using NetCoreServer;
 using Serilog;
 using System;
 using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace dpp.opentakrouter
 {
@@ -16,6 +18,10 @@ namespace dpp.opentakrouter
         public override void OnWsConnected(HttpRequest request)
         {
             Log.Information($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
+            foreach (var evt in _router.GetActiveEvents())
+            {
+                SendTextAsync(evt.ToXmlString());
+            }
         }
 
         public override void OnWsDisconnected()
@@ -27,10 +33,21 @@ namespace dpp.opentakrouter
         {
             try
             {
-                var msg = Message.Parse(buffer, (int)offset, (int)size);
+                var data = Encoding.UTF8.GetString(buffer);
 
-                Log.Information($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
-                _router.Send(msg.Event, buffer);
+                foreach (Match match in Regex.Matches(data, @"<event.+?\/event>"))
+                {
+                    try
+                    {
+                        var evt = Event.Parse(match.Value);
+                        Log.Information($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={evt.Uid} type={evt.Type}");
+                        _router.Send(evt, null);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, $"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/dpp.opentakrouter/TakWssServer.cs
+++ b/dpp.opentakrouter/TakWssServer.cs
@@ -2,7 +2,6 @@
 using Serilog;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 
 namespace dpp.opentakrouter
 {

--- a/dpp.opentakrouter/TakWssSession.cs
+++ b/dpp.opentakrouter/TakWssSession.cs
@@ -35,7 +35,7 @@ namespace dpp.opentakrouter
             {
                 var data = Encoding.UTF8.GetString(buffer);
 
-                foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                foreach (Match match in Regex.Matches(data, @"<event.+?\/event>"))
                 {
                     try
                     {

--- a/dpp.opentakrouter/TakWssSession.cs
+++ b/dpp.opentakrouter/TakWssSession.cs
@@ -3,6 +3,8 @@ using NetCoreServer;
 using Serilog;
 using System;
 using System.Net.Sockets;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace dpp.opentakrouter
 {
@@ -16,6 +18,10 @@ namespace dpp.opentakrouter
         public override void OnWsConnected(HttpRequest request)
         {
             Log.Information($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} state=connected");
+            foreach (var evt in _router.GetActiveEvents())
+            {
+                SendTextAsync(evt.ToXmlString());
+            }
         }
 
         public override void OnWsDisconnected()
@@ -27,10 +33,21 @@ namespace dpp.opentakrouter
         {
             try
             {
-                var msg = Message.Parse(buffer, (int)offset, (int)size);
+                var data = Encoding.UTF8.GetString(buffer);
 
-                Log.Information($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={msg.Event.Uid} type={msg.Event.Type}");
-                _router.Send(msg.Event, buffer);
+                foreach (Match match in Regex.Matches(data, @"<event.+\/event>"))
+                {
+                    try
+                    {
+                        var evt = Event.Parse(match.Value);
+                        Log.Information($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} event=cot uid={evt.Uid} type={evt.Type}");
+                        _router.Send(evt, null);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, $"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                    }
+                }
             }
             catch (Exception e)
             {

--- a/dpp.opentakrouter/opentakrouter.json
+++ b/dpp.opentakrouter/opentakrouter.json
@@ -5,6 +5,8 @@
         // defaults to the executable location.
         //"data": "%appdata%/opentakrouter",
 
+        "persist_messages":  false,
+
         // set the server name. this is used for api/federation functionality.
         // defaults to the hostname.
         //"name":  ""

--- a/dpp.opentakrouter/opentakrouter.json
+++ b/dpp.opentakrouter/opentakrouter.json
@@ -5,7 +5,9 @@
         // defaults to the executable location.
         //"data": "%appdata%/opentakrouter",
 
-        "persist_messages":  false,
+        // persist messages to the local database. on by default.
+        // in extreme cases this may increase throughput slightly.
+        "persist_messages": true,
 
         // set the server name. this is used for api/federation functionality.
         // defaults to the hostname.


### PR DESCRIPTION
This is a handful of improvements smashed together - namely:

- Opportunistically interpret the buffer searching for events.
- The router now has a flag, `persist_messages`, that optionally persists events to the message repository. Because of the message repository this determines if routing is IO bound. 
- On connect we actually send the active events. Ultimately these events only exist if persisting messages is enabled.


Things for the future:
- Searching the buffer for events works fine until protobuf messages are being handled; at which point we'll need to handle the protocol upgrade request and we need to revisit this.
- There is no real graceful failure mode if the server is actually drowning in data. We need to make the choice between dumping the buffer and accepting data loss or disconnecting the noisy source. This needs to be solved later. It would be nice if there was some sort of back pressure mechanism built into the CoT psuedo-protocol.

This mostly closes #19.