### PR TITLE
Fix websocket protocol selection, tls1.2

### DIFF
--- a/dpp.opentakrouter/TakService.cs
+++ b/dpp.opentakrouter/TakService.cs
@@ -52,7 +52,7 @@ namespace dpp.opentakrouter
                 var tlsServerConfig = configuration.GetSection("server:tak:tls").Get<TakServerConfig>();
                 if (tlsServerConfig is not null && tlsServerConfig.Enabled)
                 {
-                    var sslContext = new SslContext(SslProtocols.Tls, new X509Certificate(
+                    var sslContext = new SslContext(SslProtocols.Tls12, new X509Certificate(
                         tlsServerConfig.Cert,
                         tlsServerConfig.Passphrase)
                     );
@@ -76,7 +76,7 @@ namespace dpp.opentakrouter
                     var port = websocketConfig.Port ?? 5500;
                     if (websocketConfig.Ssl)
                     {
-                        var sslContext = new SslContext(SslProtocols.Tls, new X509Certificate(
+                        var sslContext = new SslContext(SslProtocols.Tls12, new X509Certificate(
                             websocketConfig.Cert,
                             websocketConfig.Passphrase)
                         );

--- a/dpp.opentakrouter/Views/Home/Map.cshtml
+++ b/dpp.opentakrouter/Views/Home/Map.cshtml
@@ -73,7 +73,7 @@
     }
 
     function Connect() {
-        var proto = window.location.protocol == "https" ? "wss" : "ws";
+        var proto = window.location.protocol == "https:" ? "wss" : "ws";
         var wsEndpoint = `${proto}://${window.location.hostname}:@ViewData["ws-port"]`;
         var ws = new WebSocket(wsEndpoint);
 


### PR DESCRIPTION
This fixes protocol selection and additionally uses tls1.2 for negotiating connections not handled by kestrel.