### PR TITLE
log ports and simplify exception messages

### DIFF
--- a/dpp.opentakrouter/TakService.cs
+++ b/dpp.opentakrouter/TakService.cs
@@ -42,7 +42,7 @@ namespace dpp.opentakrouter
                         tcpServerConfig.Port,
                         router: router);
                     _tcpServer.Start();
-                    Log.Information("server=tak-tcp state=started");
+                    Log.Information($"server=tak-tcp state=started port={tcpServerConfig.Port}");
                 }
                 else
                 {
@@ -63,7 +63,7 @@ namespace dpp.opentakrouter
                         tlsServerConfig.Port,
                         router: router);
                     _tlsServer.Start();
-                    Log.Information("server=tak-ssl state=started");
+                    Log.Information($"server=tak-ssl state=started port={tlsServerConfig.Port}");
                 }
                 else
                 {
@@ -83,13 +83,13 @@ namespace dpp.opentakrouter
 
                         _wssServer = new TakWssServer(sslContext, IPAddress.Any, port, router);
                         _wssServer.Start();
-                        Log.Information("server=wss state=started");
+                        Log.Information($"server=wss state=started port={port}");
                     }
                     else
                     {
                         _wsServer = new TakWsServer(IPAddress.Any, port, router);
                         _wsServer.Start();
-                        Log.Information("server=ws state=started");
+                        Log.Information($"server=ws state=started port={port}");
                     }
                 }
                 else
@@ -127,7 +127,7 @@ namespace dpp.opentakrouter
                             }
                             catch (Exception e)
                             {
-                                Log.Error($"peer={peerConfig.Name} error={e}");
+                                Log.Error($"peer={peerConfig.Name} error=true message=\"{e.Message}\"");
                                 continue;
                             }
                         }
@@ -141,7 +141,7 @@ namespace dpp.opentakrouter
             }
             catch (Exception e)
             {
-                Log.Error(e, "state=error");
+                Log.Error($"state=error error=true message=\"{e.Message}\"");
                 System.Environment.Exit(2);
             }
 

--- a/dpp.opentakrouter/TakTcpPeer.cs
+++ b/dpp.opentakrouter/TakTcpPeer.cs
@@ -87,7 +87,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"peer={_name} error={error}");
+            Log.Error($"peer={_name} error=true message=\"{error}\"");
         }
 
         protected override void OnReceived(byte[] buffer, long offset, long size)

--- a/dpp.opentakrouter/TakTcpServer.cs
+++ b/dpp.opentakrouter/TakTcpServer.cs
@@ -27,7 +27,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=tak-tcp error={error}");
+            Log.Error($"server=tak-tcp error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakTcpSession.cs
+++ b/dpp.opentakrouter/TakTcpSession.cs
@@ -69,7 +69,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
+            Log.Error($"server=tak-tcp endpoint={Socket.RemoteEndPoint} session={Id} error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakTlsServer.cs
+++ b/dpp.opentakrouter/TakTlsServer.cs
@@ -27,7 +27,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=tak-ssl error={error}");
+            Log.Error($"server=tak-ssl error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakTlsSession.cs
+++ b/dpp.opentakrouter/TakTlsSession.cs
@@ -58,19 +58,19 @@ namespace dpp.opentakrouter
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                        Log.Error($"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
                     }
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e, $"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                Log.Error($"server={_component} endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
+            Log.Error($"server=tak-ssl endpoint={Socket.RemoteEndPoint} session={Id} error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakWsServer.cs
+++ b/dpp.opentakrouter/TakWsServer.cs
@@ -29,7 +29,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=ws error={error}");
+            Log.Error($"server=ws error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakWsSession.cs
+++ b/dpp.opentakrouter/TakWsSession.cs
@@ -45,19 +45,19 @@ namespace dpp.opentakrouter
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, $"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                        Log.Error($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
                     }
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e, $"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                Log.Error($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
+            Log.Error($"server=ws endpoint={Socket.RemoteEndPoint} session={Id} error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakWssServer.cs
+++ b/dpp.opentakrouter/TakWssServer.cs
@@ -29,7 +29,7 @@ namespace dpp.opentakrouter
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=wss id=server error={error}");
+            Log.Error($"server=wss id=server error=true message=\"{error}\"");
         }
     }
 }

--- a/dpp.opentakrouter/TakWssSession.cs
+++ b/dpp.opentakrouter/TakWssSession.cs
@@ -45,19 +45,19 @@ namespace dpp.opentakrouter
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, $"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                        Log.Error($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
                     }
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e, $"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false");
+                Log.Error($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} type=unknown error=true forwarded=false message=\"{e.Message}\"");
             }
         }
 
         protected override void OnError(SocketError error)
         {
-            Log.Error($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} error={error}");
+            Log.Error($"server=wss endpoint={Socket.RemoteEndPoint} session={Id} error=true message=\"{error}\"");
         }
     }
 }


### PR DESCRIPTION
make things a bit more consistent by emitting ports for each service startup. additionally let's simplify the stack traces with the actual messages.